### PR TITLE
Properly cancel pending events when they are not nedded anymore: 

### DIFF
--- a/iot_control/iotdevicebase.py
+++ b/iot_control/iotdevicebase.py
@@ -26,6 +26,10 @@ class IoTDeviceBase(metaclass=ABCMeta):
         which want to schedule events by themselves. All others don't need to know about this one"""
         self.runtime= runtime
 
+    def give_scheduled_event_handle(self,handle) -> None:
+        """ give the handle for a scheduled event back to the device after it was schedules by IoTRuntime.
+        Ignore by default, overwrite if concrete class want's to do something with it"""
+
     @abstractmethod
     def read_data(self) -> Dict:
         """ Abstract method to read data """


### PR DESCRIPTION
When there is a pending auto-off-event and the switch gets manually switched off
and on again, then the old auto-off must be canceled. Then only the
auto-off-event for the latest on event remains.