### PR TITLE
new PR after merging upstream changes

### DIFF
--- a/example-setup.yaml
+++ b/example-setup.yaml
@@ -24,7 +24,7 @@ devices:
   raspi-gpio:
     payload_off: "off"
     payload_on: "on"
-    names:
+    switches:
       relais-pumpe:
         name: Relay Rooftop
         unique_id: "water_relais"

--- a/iot_control/backends/mqtthass.py
+++ b/iot_control/backends/mqtthass.py
@@ -67,7 +67,7 @@ class BackendMqttHass(IoTBackendBase):
                     self.logger.debug("new mqtt value for %s : %s", state_topic, val)
                     self.mqtt_client.publish(state_topic, json.dumps(val), retain= True)
 
-        elif "names" in thing.conf: ## TODO needs to be changed to "switches" in the code and in the config files!
+        elif "switches" in thing.conf:
             for entry in data:
                 if entry in self.state_topics:
                     val = data[entry]
@@ -133,7 +133,7 @@ class BackendMqttHass(IoTBackendBase):
                 switches = device.sensor_list()
                 # create a state topic for everyone
                 try:
-                    switches_cfg = device.conf["names"]
+                    switches_cfg = device.conf["switches"]
                     for switch in switches:
                         try:
                             self.logger.info(

--- a/iot_control/iot_devices/iotcommandswitch.py
+++ b/iot_control/iot_devices/iotcommandswitch.py
@@ -23,8 +23,8 @@ class IoTcommandswitch(IoTDeviceBase):
         super().__init__()
         setupdata = kwargs.get("config")
         self.conf = setupdata
-        for switch in self.conf["names"]:
-            sw_cfg = self.conf["names"][switch]
+        for switch in self.conf["switches"]:
+            sw_cfg = self.conf["switches"][switch]
             if not "on_command" in sw_cfg:
                 raise IoTConfigError(
                     "on_command should be set for switch {}".format(switch))
@@ -39,12 +39,12 @@ class IoTcommandswitch(IoTDeviceBase):
     def read_data(self) -> Dict:
         """ read data """
         val = {}
-        for name in self.on_cmds:
-            if self.last_state[name]:
+        for switch in self.on_cmds:
+            if self.last_state[switch]:
                 payload = self.conf["payload_on"]
             else:
                 payload = self.conf["payload_off"]
-            val[name] = payload
+            val[switch] = payload
         return val
 
     def sensor_list(self) -> list:

--- a/iot_control/iot_devices/iotraspigpio.py
+++ b/iot_control/iot_devices/iotraspigpio.py
@@ -6,6 +6,7 @@
 
 from typing import Dict
 import RPi.GPIO as GPIO
+import logging
 from iot_control.iotdevicebase import IoTDeviceBase
 from iot_control.iotfactory import IoTFactory
 
@@ -28,6 +29,14 @@ class IoTraspigpio(IoTDeviceBase):
         self.conf = setupdata
         GPIO.setmode(GPIO.BCM)  # GPIO Nummern statt Board Nummern
         GPIO.setwarnings(False)
+
+        # transition code: make sure the old version with 'names' instead of 
+        # 'switches' in setup.yaml is also accepted TODO: delete some time in the future
+        if "names" in setupdata:
+            logger = logging.getLogger("iot_control")
+            logger.info("PLEASE UPDATE: Your setup.yaml uses 'names' instead of 'switches' in the raspi-gpio section.")
+            setupdata["switches"]= setupdata["names"]
+
         switches_cfg = setupdata["switches"]
         for switch in switches_cfg:
             cfg = switches_cfg[switch]

--- a/iot_control/iot_devices/iotraspigpio.py
+++ b/iot_control/iot_devices/iotraspigpio.py
@@ -85,4 +85,7 @@ class IoTraspigpio(IoTDeviceBase):
         return True
 
     def shutdown(self, _) -> None:
-        """ nothing to do """
+        """ Make sure to switch off the GPIO pin """
+        for switch in self.switches:
+            pin = self.switches[switch]
+            GPIO.output(pin, GPIO.LOW)

--- a/iot_control/iot_devices/iotraspigpio.py
+++ b/iot_control/iot_devices/iotraspigpio.py
@@ -15,8 +15,8 @@ class IoTraspigpio(IoTDeviceBase):
     """ Raspberry pi GPIO class
     """
 
-    # stores mapping of names to pins
-    names = {}
+    # stores mapping of switches to pins
+    switches = {}
     autooff= 0
     
     # handle for a pending autooff event
@@ -28,14 +28,14 @@ class IoTraspigpio(IoTDeviceBase):
         self.conf = setupdata
         GPIO.setmode(GPIO.BCM)  # GPIO Nummern statt Board Nummern
         GPIO.setwarnings(False)
-        names_cfg = setupdata["names"]
-        for name in names_cfg:
-            cfg = names_cfg[name]
+        switches_cfg = setupdata["switches"]
+        for switch in switches_cfg:
+            cfg = switches_cfg[switch]
             pin = cfg["pin"]
             if "autooff" in cfg:
                 self.autooff= cfg["autooff"]
             GPIO.setup(pin, GPIO.OUT)  # GPIO Modus zuweisen
-            self.names[name] = pin
+            self.switches[switch] = pin
 
     def give_scheduled_event_handle(self,handle) -> None:
         self.handle= handle
@@ -43,22 +43,22 @@ class IoTraspigpio(IoTDeviceBase):
     def read_data(self) -> Dict:
         """ read data """
         val = {}
-        for name in self.names:
-            pin = self.names[name]
+        for switch in self.switches:
+            pin = self.switches[switch]
             if not GPIO.input(pin):
                 payload = self.conf["payload_off"]
             else:
                 payload = self.conf["payload_on"]
-            val[name] = payload
+            val[switch] = payload
         return val
 
     def sensor_list(self) -> list:
-        return self.names.keys()
+        return self.switches.keys()
 
     def set_state(self, messages: Dict) -> bool:
         for msg in messages:
-            if msg in self.names:
-                pin = self.names[msg]
+            if msg in self.switches:
+                pin = self.switches[msg]
                 GPIO.setup(pin, GPIO.OUT)
                 if messages[msg] == self.conf["payload_on"]:
                     GPIO.output(pin, GPIO.HIGH)

--- a/iot_control/iotdevicebase.py
+++ b/iot_control/iotdevicebase.py
@@ -26,6 +26,10 @@ class IoTDeviceBase(metaclass=ABCMeta):
         which want to schedule events by themselves. All others don't need to know about this one"""
         self.runtime= runtime
 
+    def give_scheduled_event_handle(self,handle) -> None:
+        """ give the handle for a scheduled event back to the device after it was schedules by IoTRuntime.
+        Ignore by default, overwrite if concrete class want's to do something with it"""
+
     @abstractmethod
     def read_data(self) -> Dict:
         """ Abstract method to read data """

--- a/iot_control/iotruntime.py
+++ b/iot_control/iotruntime.py
@@ -160,6 +160,9 @@ class IoTRuntime:
         finally:
             self.loop.close()
 
+        for device in self.devices:
+            device.shutdown(None)
+
         for backend in self.backends:
             backend.shutdown()
         


### PR DESCRIPTION
* Rename 'names' to 'switches' in code and in config, added transition code so that old config entries still work
* Properly cancel pending events when they are not needed anymore: When there is a pending auto-off-event and the switch gets manually switched off and on again, then the old auto-off must be canceled. Then only the auto-off-event for the latest on event remains.
* Enable the shutdown method for devices and make iotraspigpio switch off on shutdown