### PR TITLE
Add gpio binary sensor device

### DIFF
--- a/example-setup.yaml
+++ b/example-setup.yaml
@@ -83,3 +83,17 @@ devices:
         unique_id: "pressure_rooftop"
         unit_of_measurement: "hPa"
         expire_after: 370
+raspi-binary-sensor:
+    payload_off: "OFF"
+    payload_on: "ON"
+    binary-sensors:
+      button:
+        name: Button
+        unique_id: "button"
+        device_class: door  # device class according to https://www.home-assistant.io/integrations/binary_sensor/#device-class
+        pin: 15 # PIN as GPIO number, not board number
+      anotherbutton:
+        name: Anotherbutton
+        unique_id: "button2"
+        device_class: window  # device class according to https://www.home-assistant.io/integrations/binary_sensor/#device-class
+        pin: 18 # PIN as GPIO number, not board number

--- a/iot_control/iot_devices/iotbinarysensor.py
+++ b/iot_control/iot_devices/iotbinarysensor.py
@@ -23,16 +23,12 @@ class IoTbinarysensor(IoTDeviceBase):
     handle = None
 
     def __callback(self, pin, state, cfg):
-        """ The real callback function actin upon a state change of one of the GPIO pins """
-        print( "__callback:" )
-        print( "    pin:", pin )
-        print( "    state:", state )
-        print( "    cfg:", cfg )
+        """ The real callback function acting upon a state change of one of the GPIO pins """
+        self.runtime.trigger_for_device(self)
 
     def __init__(self, **kwargs):
         super().__init__()
         setupdata = kwargs.get("config")
-        print("new IoTbinarysensor: ", setupdata)
         self.conf = setupdata
         GPIO.setmode(GPIO.BCM)  # GPIO Nummern statt Board Nummern
         GPIO.setwarnings(False)
@@ -42,9 +38,7 @@ class IoTbinarysensor(IoTDeviceBase):
         def callback( pin ):
             """ Helper callback function providing all the interesting arguments that the stupid API of 
             GPIO.add_event_detect() doesn't like to give us"""
-            #print( "callback on ", pin )
             for sensor in sensors_cfg:
-                #print( "try sensor ", sensor )
                 if "pin" in sensors_cfg[sensor] and sensors_cfg[sensor]["pin"] == pin:
                     self.__callback(pin, not GPIO.input(pin), sensors_cfg[sensor])
 
@@ -77,8 +71,8 @@ class IoTbinarysensor(IoTDeviceBase):
         return self.sensors.keys()
 
     def set_state(self, messages: Dict) -> bool:
-        print( "IoTbinarysensor.set_state() cannot act on messages", messages)
-        return False # True
+        """ should not happen because this device won't accept a state change """
+        return False 
 
     def shutdown(self, _) -> None:
         """ Don't need to clean up for input pins """

--- a/iot_control/iot_devices/iotbinarysensor.py
+++ b/iot_control/iot_devices/iotbinarysensor.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+""" definitions for GPIO pins on a raspberry pi as binary sensors
+"""
+
+from typing import Dict
+import RPi.GPIO as GPIO
+import logging
+from iot_control.iotdevicebase import IoTDeviceBase
+from iot_control.iotfactory import IoTFactory
+
+
+@IoTFactory.register_device("binary-sensor")
+class IoTbinarysensor(IoTDeviceBase):
+    """ binary sensor class to act upon an input GPIO pin on a Raspi
+    """
+
+    # stores mapping of binary sensors to pins
+    sensors = {}
+    
+    # handle for a pending autooff event
+    handle = None
+
+    def __callback(self, pin, state, cfg):
+        """ The real callback function actin upon a state change of one of the GPIO pins """
+        print( "__callback:" )
+        print( "    pin:", pin )
+        print( "    state:", state )
+        print( "    cfg:", cfg )
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        setupdata = kwargs.get("config")
+        print("new IoTbinarysensor: ", setupdata)
+        self.conf = setupdata
+        GPIO.setmode(GPIO.BCM)  # GPIO Nummern statt Board Nummern
+        GPIO.setwarnings(False)
+
+        sensors_cfg = setupdata["binary-sensors"]
+
+        def callback( pin ):
+            """ Helper callback function providing all the interesting arguments that the stupid API of 
+            GPIO.add_event_detect() doesn't like to give us"""
+            #print( "callback on ", pin )
+            for sensor in sensors_cfg:
+                #print( "try sensor ", sensor )
+                if "pin" in sensors_cfg[sensor] and sensors_cfg[sensor]["pin"] == pin:
+                    self.__callback(pin, not GPIO.input(pin), sensors_cfg[sensor])
+
+        for sensor in sensors_cfg:
+            cfg = sensors_cfg[sensor]
+            pin = cfg["pin"]
+            if "device_class" in cfg:
+                self.device_class = cfg["device_class"]
+            else:
+                self.device_class = None
+
+            GPIO.setup(pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)  # GPIO Modus zuweisen
+            self.sensors[sensor] = pin
+
+            GPIO.add_event_detect( pin, GPIO.BOTH, callback= callback, bouncetime=100 )
+
+    def read_data(self) -> Dict:
+        """ read data """
+        val = {}
+        for sensor in self.sensors:
+            pin = self.sensors[sensor]
+            if not GPIO.input(pin):
+                payload = self.conf["payload_off"]
+            else:
+                payload = self.conf["payload_on"]
+            val[sensor] = payload
+        return val
+
+    def sensor_list(self) -> list:
+        return self.sensors.keys()
+
+    def set_state(self, messages: Dict) -> bool:
+        print( "IoTbinarysensor.set_state() cannot act on messages", messages)
+        return False # True
+
+    def shutdown(self, _) -> None:
+        """ Don't need to clean up for input pins """
+        for sensor in self.sensors:
+            pin = self.sensors[sensor]
+            #GPIO.output(pin, GPIO.LOW)

--- a/iot_control/iot_devices/iotraspibinarysensor.py
+++ b/iot_control/iot_devices/iotraspibinarysensor.py
@@ -11,8 +11,8 @@ from iot_control.iotdevicebase import IoTDeviceBase
 from iot_control.iotfactory import IoTFactory
 
 
-@IoTFactory.register_device("binary-sensor")
-class IoTbinarysensor(IoTDeviceBase):
+@IoTFactory.register_device("raspi-binary-sensor")
+class IoTraspibinarysensor(IoTDeviceBase):
     """ binary sensor class to act upon an input GPIO pin on a Raspi
     """
 

--- a/iot_control/iotruntime.py
+++ b/iot_control/iotruntime.py
@@ -16,6 +16,7 @@ import iot_control.iot_devices.iotbme280
 import iot_control.iot_devices.iotbh1750
 import iot_control.iot_devices.iotraspigpio
 import iot_control.iot_devices.iotcommandswitch
+import iot_control.iot_devices.iotbinarysensor
 import iot_control.backends.influx
 import iot_control.backends.mqtthass
 from iot_control.iotfactory import IoTFactory

--- a/iot_control/iotruntime.py
+++ b/iot_control/iotruntime.py
@@ -16,7 +16,7 @@ import iot_control.iot_devices.iotbme280
 import iot_control.iot_devices.iotbh1750
 import iot_control.iot_devices.iotraspigpio
 import iot_control.iot_devices.iotcommandswitch
-import iot_control.iot_devices.iotbinarysensor
+import iot_control.iot_devices.iotraspibinarysensor
 import iot_control.backends.influx
 import iot_control.backends.mqtthass
 from iot_control.iotfactory import IoTFactory

--- a/iot_control/iotruntime.py
+++ b/iot_control/iotruntime.py
@@ -174,6 +174,34 @@ class IoTRuntime:
         self.loop.call_soon_threadsafe(
             functools.partial(IoTRuntime.__schedule_from_local_thread,self,delay,device,switch,event))
         
+    def triggered_update(self, device):
+        """ handler for trigger_for_device(), call from the main event handler
+
+        Args:
+            device (IOTdevicebase): the device
+            switch (str): the switch on the device
+            event (str): the message to send
+        """
+        for backend in self.backends:
+            data = device.read_data()
+            backend.workon(device, data)
+
+    def trigger_for_device(self,device):
+        """ Act on notification by a device, like schedule_for_device() but without a delay,
+            it makes the runtime call workon() for this device, mainly to be used with mqtt
+
+        Args:
+            device (IOTdevicebase): the device
+        """
+        if self.loop is None:
+            self.logger.error("no event loop created, must not call 'IoTRuntime.schedule_for_device()' yet")
+            return None
+       
+        # This get's (most likely) called from another thread such as a GPIO callback thread but
+        # not the thread where self.loop lives in. Therefore, the following call makes self.loop()
+        # to call self.trigger_for_device() soon inside the thread of self.loop
+        self.loop.call_soon_threadsafe(functools.partial(IoTRuntime.triggered_update,self,device))
+
     def loop_forever(self):
         """ the main loop of the runtime
         """


### PR DESCRIPTION
Add a binary-sensor device that acts on RPI.GPIO input pins. Naming according to Home Assistant, see https://www.home-assistant.io/integrations/binary_sensor/.